### PR TITLE
Accept git directories containing spaces

### DIFF
--- a/git_review/cmd.py
+++ b/git_review/cmd.py
@@ -155,7 +155,7 @@ def git_directories():
     cmd = ("git", "rev-parse", "--show-toplevel", "--git-dir")
     out = run_command_exc(GitDirectoriesException, *cmd)
     try:
-        return out.split()
+        return out.split("\n")
     except ValueError:
         raise GitDirectoriesException(0, out, cmd, {})
 


### PR DESCRIPTION
Split on \n instead of any whitespace. This would previously generate cryptic ValueError: too many values to unpack if git-review was run on a directory with any spaces in the path.

I did not test if everything works yet, but this is definitely needed for anything to work.
