### PR TITLE
Allow --no-thin option for git push

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Example .gitreview file (used to upload for git-review itself)::
 Required values: host, project
 
 Optional values: port (default: 29418), defaultbranch (default: master),
-defaultremote (default: gerrit).
+defaultremote (default: gerrit), disablethinpush (default: false)
 
 **Notes**
 


### PR DESCRIPTION
Add workaround for long-lasting bug with git optimization "thin push" and gerrit.
- Option "disablethinpush" added to config file parsing (default: false)
- Option "--no-thin" added to command-line parsing (ex: git review --no-thin)

Referenced: https://bugs.launchpad.net/git-review/+bug/1332549
Issue: 1332549
