### PR TITLE
Correct misleading error message

### DIFF
--- a/git_review/cmd.py
+++ b/git_review/cmd.py
@@ -886,8 +886,9 @@ def assert_one_change(remote, branch, yes, have_hook):
                   "installed. Amending the commit to add a gerrit change id.")
         run_command("git commit --amend", GIT_EDITOR='true')
     elif output_lines == 0:
-        printwrap("No changes between HEAD and %s/%s. Submitting for review "
-                  "would be pointless." % (remote, branch))
+        printwrap("All your commits are already present on %s. If you pushed"
+                  "your commits to an upstream branch and not into review consider"
+                  "removing this branch and try git review %s again." % (remote, branch))
         sys.exit(1)
     elif output_lines > 1:
         if not yes:


### PR DESCRIPTION
The old message was misleading because it implied that the change which
is about to be pushed into review is already on the upstream branch.
But this is not the case since the change can be on any other upstream
branch.

For example:
    * test commit [branch][origin/branch]
    |
    * commit [master][origin/master]

    git review master would yield:
    No changes between HEAD and origin/master. Submitting for review
    would be pointless.

Right now I don't have a better idea how to tweak the "git log" command
to yield exactly the information needed here.