### PR TITLE
Remove empty arguments from commands

### DIFF
--- a/git_review/cmd.py
+++ b/git_review/cmd.py
@@ -128,6 +128,7 @@ def build_review_number(review, patchset):
 
 
 def run_command_status(*argv, **kwargs):
+    argv = [arg for arg in argv if arg]
     if VERBOSE:
         print(datetime.datetime.now(), "Running:", " ".join(argv))
     if len(argv) == 1:


### PR DESCRIPTION
When running git review -d xx I was getting an error when git-review was running the command:
ssh -x  xxx@xxx gerrit query --format=JSON --current-patch-set change:27268

After some investigating, it was because this was the arguments being sent to Popen:
('ssh', '-x', '', u'xxx@xxx', 'gerrit', 'query', '--format=JSON --current-patch-set change:27268')
(notice the third argument is an empty string, this was because the port number was set to be empty).

This fix removes any empty arguments from the argument list, solving this problem.