### PR TITLE
Fix "git-review -d" erases work directory if on the same branch

### DIFF
--- a/git_review/cmd.py
+++ b/git_review/cmd.py
@@ -1088,8 +1088,8 @@ class CheckoutExistingBranchFailed(CommandFailed):
     EXIT_CODE = 65
 
 
-class ResetHardFailed(CommandFailed):
-    "Failed to hard reset downloaded branch"
+class ResetKeepFailed(CommandFailed):
+    "Failed to reset downloaded branch"
     EXIT_CODE = 66
 
 
@@ -1202,8 +1202,8 @@ def checkout_review(branch_name, remote, remote_branch):
                 raise BranchTrackingMismatch
             run_command_exc(CheckoutExistingBranchFailed,
                             "git", "checkout", branch_name)
-            run_command_exc(ResetHardFailed,
-                            "git", "reset", "--hard", "FETCH_HEAD")
+            run_command_exc(ResetKeepFailed,
+                            "git", "reset", "--keep", "FETCH_HEAD")
         else:
             raise
 


### PR DESCRIPTION
When working with git you do not expect that anything might be reset after changing the branch. And 'git review -d...' is much more like a branch change and does not say anything about reset.

This pull request uses git reset --keep FETCH_HEAD to keep all existing changes. After that you might see any changes to last commit in your diff.

https://storyboard.openstack.org/#!/story/1096057