### PR TITLE
Fixed review download error when topic is empty

### DIFF
--- a/git_review/cmd.py
+++ b/git_review/cmd.py
@@ -1207,6 +1207,7 @@ def fetch_review(review, masterbranch, remote, project):
     try:
         if patchset_number is None:
             refspec = review_info['currentPatchSet']['ref']
+            patchset_number = review_info['currentPatchSet']['number']
         else:
             refspec = [ps for ps in review_info['patchSets']
                        if ps['number'] == patchset_number][0]['ref']


### PR DESCRIPTION
I think I tracked down the cause of a problem. It is about an exception handler, which is incomplete. 

My problem occurred only if I had no title set in Gerrit and let to a situation in which `git review -d [CHANGE]` tried to
`git clone branch/user/`
as opposed to
`git clone branch/user`
That leads to an error because after a slash usually follows the topic and if that is empty the checkout does not work as expected. It instead stops with an error message `remote branch not found`.